### PR TITLE
fix code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ generator:
 parse post overriden options
 ```typescript
 const { parsePost } = require('hexo-post-parser');
-parsePost('/path/to/file.md', {
+
+const filePath = '/path/to/file.md';
+parsePost(filePath, {
 shortcodes: {
   youtube: true,
   css: true,
@@ -55,7 +57,7 @@ config: {
 },
 formatDate: true,
 fix: true,
-sourceFile: file.path
+sourceFile: filePath
 })
 ```
 


### PR DESCRIPTION
I ran into `ReferenceError: file is not defined` because the code sample was referencing a `file.path` and the `file` was not specified further. Here is a small PR that fixes this.